### PR TITLE
Include 3.11 and 3.10 in the build matrix for scikit-learn

### DIFF
--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         image_tag:
           - 3.12-alpine
+          - 3.11-alpine
+          - 3.10-alpine
         platform:
           - linux/amd64
           - linux/arm/v7


### PR DESCRIPTION
Include 3.11 and 3.10 in the build matrix