### PR TITLE
Add aarch64 and armhf

### DIFF
--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -26,6 +26,8 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm/v7
+          - linux/aarch64
+          - linux/arm/hf
 
     steps:
 


### PR DESCRIPTION
Hello! You recently added armv7 for me. I am trying to use this package on home assistant, so I need support for a few more archs.

I hope this is okay!